### PR TITLE
Correctly highlight const

### DIFF
--- a/iro.gemspec
+++ b/iro.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency 'minitest', '~> 5.11'
+  spec.add_development_dependency 'unification_assertion'
+
   spec.add_development_dependency 'sanitize', '~> 4.6'
 end

--- a/lib/iro/ruby/parser.rb
+++ b/lib/iro/ruby/parser.rb
@@ -14,8 +14,6 @@ module Iro
         embdoc_beg: 'Comment',
         embdoc_end: 'Comment',
 
-        const: 'Type',
-        
         regexp_beg: 'Delimiter',
         regexp_end: 'Delimiter',
         heredoc_beg: 'Delimiter',
@@ -118,9 +116,30 @@ module Iro
 
       def on_var_ref(name)
         super.tap do
-          if name.ident_type?
+          case name.type
+          when :@ident
             register_scanner_event 'rubyLocalVariable', name
+          when :@const
+            register_scanner_event 'Type', name
           end
+        end
+      end
+
+      def on_var_field(name)
+        super.tap do
+          register_scanner_event 'Type', name if name.const_type?
+        end
+      end
+
+      def on_top_const_ref(name)
+        super.tap do
+          register_scanner_event 'Type', name
+        end
+      end
+
+      def on_const_path_ref(_base, name)
+        super.tap do
+          register_scanner_event 'Type', name
         end
       end
 

--- a/test/iro/ruby/parser_test.rb
+++ b/test/iro/ruby/parser_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
 class TestIroRubyParser < Minitest::Test
+  include UnificationAssertion
+
   def assert_parse(expected, source)
     got = Iro::Ruby::Parser.tokens(source)
-    assert_equal(expected, got)
+    assert_unifiable(expected, got)
   end
 
   def test_tokens_string
@@ -161,6 +163,28 @@ class TestIroRubyParser < Minitest::Test
         :$foo
         :@foo
         :@@foo
+      RUBY
+    )
+  end
+
+  def test_const
+    assert_parse(
+      {
+        "Type" => [[1, 1, 3], [2, 3, 3], [3, 5, 3], [4, 3, 3], [4, 8, 3]],
+        "rubySymbol" => :_,
+        "Keyword" => :_,
+        "rubyDefine" => :_,
+        "rubyFunction" => :_,
+        "rubySymbolDelimiter" => :_,
+      }, <<~RUBY
+        Foo = _
+        p Foo
+        p ::Foo
+        p Foo::Bar
+
+        p :Foo
+        Foo()
+        def Foo() end
       RUBY
     )
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,5 +2,6 @@ require 'sanitize'
 
 require 'minitest'
 require 'minitest/autorun'
+require 'unification_assertion'
 
 require 'iro'


### PR DESCRIPTION
```ruby
:Foo # It is not a const
Foo() # It is also not a const

Foo # It is a const
Foo::Bar # They are const
::Foo # const
Foo = _ # const
```